### PR TITLE
Build for scalikejdbc 3.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 sudo: false
 scala:
-  - 2.12.8
-  - 2.13.0
+  - 2.12.10
+  - 2.13.1
 before_script:
   - mkdir lib
   - curl -L -o AthenaJDBC41_2.0.7.jar https://s3.amazonaws.com/athena-downloads/drivers/JDBC/SimbaAthenaJDBC_2.0.7/AthenaJDBC41_2.0.7.jar

--- a/build.sbt
+++ b/build.sbt
@@ -2,22 +2,22 @@ organization := "com.zaneli"
 
 name := "scalikejdbc-athena"
 
-version := "0.2.2"
+version := "0.2.3"
 
-val Scala212 = "2.12.8"
+val Scala212 = "2.12.10"
 
 scalaVersion := Scala212
 
-crossScalaVersions := Seq(Scala212, "2.13.0")
+crossScalaVersions := Seq(Scala212, "2.13.1")
 
-val scalikejdbcVersion = "3.3.5"
+val scalikejdbcVersion = "3.4.0"
 
 libraryDependencies ++= Seq(
   "org.scalikejdbc" %% "scalikejdbc" % scalikejdbcVersion % Provided,
-  "com.typesafe" % "config" % "1.3.4" % Provided,
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
+  "com.typesafe" % "config" % "1.4.0" % Provided,
+  "org.scalatest" %% "scalatest" % "3.1.1" % Test,
   "org.scalikejdbc" %% "scalikejdbc-syntax-support-macro" % scalikejdbcVersion % Test,
-  "com.h2database" % "h2" % "1.4.199" % Test
+  "com.h2database" % "h2" % "1.4.200" % Test
 )
 
 publishTo := sonatypePublishTo.value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.8


### PR DESCRIPTION
Scalikejdbc 3.4.0 introduced some changes which made it binary incompatible with previous versions. To fix it, a build against the latest scalikejdbc version is necessary. 